### PR TITLE
Three new feature on colors.

### DIFF
--- a/snippets/callout-styling.css
+++ b/snippets/callout-styling.css
@@ -26,6 +26,21 @@
   --callout-icon: lucide-highlighter 
 }
 
+.callout[data-callout="annotation-purple"] {
+  --callout-color: 162, 138, 229;
+  --callout-icon: lucide-highlighter 
+}
+
+.callout[data-callout="annotation-magenta"] {
+  --callout-color: 229, 110, 238;
+  --callout-icon: lucide-highlighter 
+}
+
+.callout[data-callout="annotation-orange"] {
+  --callout-color: 241, 152, 55;
+  --callout-icon: lucide-highlighter 
+}
+
 /* note */
 .callout[data-callout="note-yellow"] {
   --callout-color: 255, 212, 0;
@@ -51,4 +66,3 @@
   --callout-color: 162, 138, 229;
   --callout-icon: lucide-sticky-note 
 }
-

--- a/snippets/callout-styling.css
+++ b/snippets/callout-styling.css
@@ -41,6 +41,11 @@
   --callout-icon: lucide-highlighter 
 }
 
+.callout[data-callout="annotation-gray"] {
+  --callout-color: 170, 170, 170;
+  --callout-icon: lucide-highlighter 
+}
+
 /* note */
 .callout[data-callout="note-yellow"] {
   --callout-color: 255, 212, 0;

--- a/templates/literature-note.md
+++ b/templates/literature-note.md
@@ -75,14 +75,9 @@ aliases: ["{%- if authors -%}
 "blue": "#2ea8e5",
 "purple": "#a28ae5",
 "magenta": "#e56eee",
-"orange": "#f19837"
+"orange": "#f19837",
+"gray": "#aaaaaa"
 #}
-{%- set hexes = [
-"#5fb236","#ffd400",
-"#ff6666","#2ea8e5",
-"#a28ae5","#e56eee",
-"#f19837"]
--%}
 {%- set colorToColorCategorie = {
 "#5fb236": "green",
 "#ffd400": "yellow",
@@ -90,7 +85,8 @@ aliases: ["{%- if authors -%}
 "#2ea8e5": "blue",
 "#a28ae5": "purple",
 "#e56eee": "magenta",
-"#f19837": "orange"
+"#f19837": "orange",
+"#aaaaaa": "gray"
 }
 -%}
 {%- set colorCategoriesToType = {
@@ -100,7 +96,8 @@ aliases: ["{%- if authors -%}
 "blue": "Question / Understanding / Vocabulary",
 "purple": "Reference / Term to lookup later",
 "magenta": "Todo / Read later",
-"orange": "Undefined"
+"orange": "Undefined",
+"gray": "Undefined"
 }
 -%}
 {# lookup Zotero colors in annotations with categories #}

--- a/templates/literature-note.md
+++ b/templates/literature-note.md
@@ -68,12 +68,39 @@ aliases: ["{%- if authors -%}
 		{%- endif -%}
 {%- endmacro -%}
 
-{%- set colorCategories = {
+{# colorCategorie to hex:
+"green": "#5fb236",
+"yellow": "#ffd400",
+"red": "#ff6666",
+"blue": "#2ea8e5",
+"purple": "#a28ae5",
+"magenta": "#e56eee",
+"orange": "#f19837"
+#}
+{%- set hexes = [
+"#5fb236","#ffd400",
+"#ff6666","#2ea8e5",
+"#a28ae5","#e56eee",
+"#f19837"]
+-%}
+{%- set colorToColorCategorie = {
+"#5fb236": "green",
+"#ffd400": "yellow",
+"#ff6666": "red",
+"#2ea8e5": "blue",
+"#a28ae5": "purple",
+"#e56eee": "magenta",
+"#f19837": "orange"
+}
+-%}
+{%- set colorCategoriesToType = {
 "yellow": "Relevant / Important",
 "red": "Disagree",
 "green": "Important to me",
 "blue": "Question / Understanding / Vocabulary",
-"purple": "Reference / Term to lookup later"
+"purple": "Reference / Term to lookup later",
+"magenta": "Todo / Read later",
+"orange": "Undefined"
 }
 -%}
 {# lookup Zotero colors in annotations with categories #}
@@ -84,6 +111,15 @@ aliases: ["{%- if authors -%}
 {{colorCategories["yellow"]}}
 {%endif%}
 {%- endmacro -%}
+
+{%- macro colorToName(noteColor) -%}
+{%- if colorToColorCategorie[noteColor]-%}
+{{colorCategoriesToType[colorToColorCategorie[noteColor]]}}
+{% else %}
+{{colorCategoriesToType["orange"]}}
+{%endif%}
+{%- endmacro -%}
+
 
 {%- set calloutHeaders = {
 "highlight": "Relevant / Important",
@@ -218,10 +254,13 @@ aliases: ["{%- if authors -%}
 {% if newAnnotations.length > 0 %}
 {{ " " }}
 ⬇️*Imported (Annotations) on {{importDate | format("YYYY-MM-DD#HH:mm:ss")}}*⬇️
-{% for colorCategory, newAnnotations in newAnnotations | groupby("colorCategory") -%}
-#### {{colorCategoryToName(colorCategory | lower)}}
-{% for annotation in newAnnotations -%}
-> [!annotation-{% if annotation.color %}{{annotation.colorCategory | lower}}]{% endif %} {{calloutHeader(annotation.type)}}
+{% for color, colorCategorie in colorToColorCategorie %}
+{#Filter empty colorCategorie#}
+{%- for annotation in newAnnotations | filterby ("color", "startswith", color) -%}
+{% if loop.first -%}
+#### {{colorToName(color | lower)-}}
+{% endif %}
+> [!annotation-{% if annotation.color %}{{colorToColorCategorie[annotation.color]}}]{% endif %} {{calloutHeader(annotation.type)}}
 {%- if annotation.annotatedText.length > 0 -%} 
 > {{annotation.annotatedText | nl2br }} (p. [{{annotation.page}}](zotero://open-pdf/library/items/{{annotation.attachment.itemKey}}?page={{annotation.page}}&annotation={{annotation.id}})){% endif %}{%- if annotation.imageRelativePath -%}
 > ![[{{annotation.imageRelativePath}}|300]]


### PR DESCRIPTION
Hi, I have tried your wonderful template, and I really appreciate it. : )

During the process of using it, I found some areas to improve.

1. There may be a bug in Zotero. The purple color is exported as blue in the field "colorCategory". See the figure for details.
![image](https://user-images.githubusercontent.com/29939308/220337546-b77b7ac7-3932-4424-93c1-127d29acb41a.png)

To solve this problem, I add a mapping from hex to color (around lines 71-121).

2. It is pretty good to fix the order of colors. However, the output order of "groupby" depends on the order of colors in the origin list.

To solve this problem, I add an iterating over the colors and use "filterby" to filter the specific color. Then I add a judgment to resolve the corner case that there is no entry for a specific color. (around lines 257-262)

3. There will be three new colors in the next version of Zotero. I add support for these new colors. (See https://forums.zotero.org/discussion/95440/highlight-colours/p2 for new colors.)

Besides, I encountered a bug when importing notes, so I just added features for annotations.

Hope my work would make the project better. Have a nice day! ; )